### PR TITLE
Setup hygraph schema with enum creation

### DIFF
--- a/scripts/setup-hygraph-schema.ts
+++ b/scripts/setup-hygraph-schema.ts
@@ -106,13 +106,13 @@ async function createEnumeration(apiId: string, displayName: string, values: str
   }));
 
   const mutation = `
-    mutation CreateEnumeration($environmentId: ID!, $apiId: String!, $displayName: String!, $values: [EnumerationValueCreateInput!]!) {
+    mutation CreateEnumeration($apiId: String!, $displayName: String!, $values: [EnumerationValueCreateInput!]!, $environmentId: ID!) {
       createEnumeration(
-        environmentId: $environmentId
         data: {
           apiId: $apiId
           displayName: $displayName
           values: $values
+          environmentId: $environmentId
         }
       ) {
         __typename # Requesting __typename ensures a valid, minimal payload is returned
@@ -121,10 +121,10 @@ async function createEnumeration(apiId: string, displayName: string, values: str
   `;
   
   await graphqlRequest(mutation, { 
-    environmentId, 
     apiId, 
     displayName, 
-    values: formattedValues 
+    values: formattedValues,
+    environmentId 
   });
   
   // Add a small delay for Hygraph to process the async operation
@@ -137,13 +137,13 @@ async function createModel(apiId: string, displayName: string, fields: any[], en
   
   // NOTE: The management API for model creation requires environmentId
   const mutation = `
-    mutation CreateModel($environmentId: ID!, $apiId: String!, $displayName: String!, $fields: [FieldCreateInput!]!) {
+    mutation CreateModel($apiId: String!, $displayName: String!, $fields: [FieldCreateInput!]!, $environmentId: ID!) {
       createModel(
-        environmentId: $environmentId
         data: {
           apiId: $apiId
           displayName: $displayName
           fields: $fields
+          environmentId: $environmentId
         }
       ) {
         __typename # Requesting __typename ensures a valid, minimal payload is returned
@@ -152,10 +152,10 @@ async function createModel(apiId: string, displayName: string, fields: any[], en
   `;
   
   await graphqlRequest(mutation, { 
-    environmentId,
     apiId, 
     displayName, 
-    fields 
+    fields,
+    environmentId 
   });
 
   // Add a small delay for Hygraph to process the async operation


### PR DESCRIPTION
Move `environmentId` into the `data` input object for Hygraph `createEnumeration` and `createModel` mutations to resolve GraphQL validation errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c3580e0c-248d-42a4-8a73-95a77de34cc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c3580e0c-248d-42a4-8a73-95a77de34cc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

