### PR TITLE
Scan project for structure

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -162,6 +162,14 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   // Listen for auth state changes
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      // Check if we should suppress auth redirects (e.g., during admin user creation)
+      const suppressRedirect = sessionStorage.getItem('suppressAuthRedirect');
+      
+      if (suppressRedirect) {
+        console.log('Auth state change suppressed during user creation');
+        return;
+      }
+      
       setCurrentUser(user);
       
       if (user) {

--- a/src/lib/firebaseSecondary.ts
+++ b/src/lib/firebaseSecondary.ts
@@ -1,0 +1,64 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/**
+ * Secondary Firebase App Configuration
+ * 
+ * This file creates a separate Firebase app instance specifically for admin user creation.
+ * The secondary auth instance prevents the main app's authentication state from being affected
+ * when admins create new users, avoiding unwanted redirects and session conflicts.
+ * 
+ * How it works:
+ * 1. Creates a separate Firebase app with name 'secondary'
+ * 2. Exports a separate auth instance (secondaryAuth) 
+ * 3. User creation uses this secondary auth, then immediately signs out
+ * 4. Main app's auth state remains unchanged, preventing redirects
+ */
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth, connectAuthEmulator, setPersistence, browserSessionPersistence } from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
+
+// Use the same config as the main Firebase app
+const firebaseConfig = {
+  apiKey: import.meta.env.VITE_FIREBASE_API_KEY || "AIzaSyBtIY1wVdePkWCJ84bSr7alOMcI2aihVqw",
+  authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || "school-management-system-67b85.firebaseapp.com",
+  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || "school-management-system-67b85",
+  storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || "school-management-system-67b85.appspot.com",
+  messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "103441012203195276037",
+  appId: import.meta.env.VITE_FIREBASE_APP_ID || "1:103441012203195276037:web:abc123def456ghi789"
+};
+
+// Initialize secondary Firebase app with a unique name
+// This prevents conflicts with the main app and ensures separate auth state
+let secondaryApp;
+const existingApps = getApps();
+const secondaryAppName = 'secondary';
+
+// Check if secondary app already exists to avoid duplicate initialization
+if (existingApps.find(app => app.name === secondaryAppName)) {
+  secondaryApp = existingApps.find(app => app.name === secondaryAppName);
+} else {
+  secondaryApp = initializeApp(firebaseConfig, secondaryAppName);
+}
+
+// Initialize secondary Firebase Authentication
+// This auth instance is completely separate from the main app's auth
+export const secondaryAuth = getAuth(secondaryApp);
+setPersistence(secondaryAuth, browserSessionPersistence);
+
+// Initialize secondary Firestore (optional, but good for consistency)
+export const secondaryDb = getFirestore(secondaryApp);
+
+// Connect to emulators in development (same as main app)
+if (import.meta.env.DEV) {
+  try {
+    if (!secondaryAuth.config) {
+      // connectAuthEmulator(secondaryAuth, "http://localhost:9099");
+    }
+    if (!(secondaryDb as any)._delegate._databaseId.projectId.includes('demo-')) {
+      // connectFirestoreEmulator(secondaryDb, 'localhost', 8080);
+    }
+  } catch (error) {
+    console.log('Secondary app emulators already connected or not available');
+  }
+}
+
+export default secondaryApp;


### PR DESCRIPTION
Refactor user creation to use a secondary Firebase app to prevent admin redirects when creating new users.

When an admin used `createUserWithEmailAndPassword` with the main Firebase `auth` instance, Firebase would automatically sign in the newly created user. This change in the main authentication state triggered the `onAuthStateChanged` listener, leading to an unwanted redirect of the admin to the new user's dashboard. By using a separate, "secondary" Firebase app for user creation, the main app's authentication state remains unaffected, ensuring the admin stays on the `UserManager.tsx` page. A `sessionStorage` flag is also added as an extra safeguard to temporarily suppress any potential auth-related redirects during the user creation process.

---
<a href="https://cursor.com/background-agent?bcId=bc-45b2c95b-51ea-4f42-92f5-4043194f8ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-45b2c95b-51ea-4f42-92f5-4043194f8ee0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

